### PR TITLE
build(other): Add automated npm publish workflow

### DIFF
--- a/.github/workflows/enforce-conventional-pr-title.yml
+++ b/.github/workflows/enforce-conventional-pr-title.yml
@@ -16,7 +16,7 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       !contains(github.actor, '[bot]') &&
       github.event.pull_request.draft == false
-    runs-on: gh-2-core-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: "Publish to npm"
+run-name: Deploy ${{ github.repository }} to npmjs by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  publish:
+    uses: braintree/web-sdk-github-actions/.github/workflows/publish.yml@main
+    with:
+      version-type: ${{ inputs.version_type }}
+    secrets:
+      npm-token: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+## UNRELEASED
+
 ## 1.0.4
 
 - Add @types/node 24.0.0


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch`-triggered publish workflow that uses the shared reusable workflow from [`braintree/web-sdk-github-actions`](https://github.com/braintree/web-sdk-github-actions)
- Pipeline: CI (lint + test) → version bump → npm publish (with provenance) → GitHub release notes
- Triggered manually with version type selection (patch, minor, major)
- Adds `## UNRELEASED` section to CHANGELOG.md (required by the version-bump action)

## How it works

The thin `publish.yml` calls the shared `braintree/web-sdk-github-actions/.github/workflows/publish.yml` workflow, which orchestrates:

1. **CI** — runs existing lint and test suite; publish is blocked if tests fail
2. **Version bump** — `npm version`, updates CHANGELOG (UNRELEASED → version + date), commits, tags, pushes
3. **npm publish** — `npm publish --provenance` using org-level `BRAINTREE_NPM_ACCESS_TOKEN`
4. **Release notes** — auto-generates GitHub release from tag + changelog

## Test plan

- [ ] Verify "Publish to npm" workflow appears in Actions tab after merge
- [ ] Confirm `workflow_dispatch` trigger shows version_type dropdown (patch/minor/major)
- [ ] Validate end-to-end on next planned release